### PR TITLE
fix extraction for `validateAddress` by flattening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ vignettes/*.pdf
 # Scratch or Local files
 /*.R
 data-local/
+.Rdata
+.DS_Store

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: addressr
 Type: Package
 Title: Verify Raw, Unstructured Addresses
-Version: 0.1.4
+Version: 0.1.5
 Authors@R: person("McClelland", "Legge", , "McClelland.Legge@gmail.com", c("aut", "cre"))
 Maintainer: McClelland Legge <McClelland.Legge@gmail.com>
 Description: A package to handle poorly formed address inputs (presumably from

--- a/R/extract_response.R
+++ b/R/extract_response.R
@@ -5,6 +5,9 @@ extractResponseItems <- function(response) {
          call. = FALSE)
   }
 
+  # flatten from list of batches of 5 to list of responses
+  response <- unlist(response, recursive = FALSE)
+
   # convert each item to a data table retaining the ID attribute
   dt_list <- lapply(response, function(resp_item) {
     # extract the id attribute for rejoining with the indexed set


### PR DESCRIPTION
Requests come back in batches of 5 or less (max for the USPS api), but extraction expects a list of address objects. This flattens the former to get the latter.

Fixes https://github.com/McClellandLegge/addressr/issues/2.



